### PR TITLE
BGP now can use either book.xml or book.plaintext, as needed

### DIFF
--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -10,5 +10,51 @@
 """
 
 __title__ = 'bgp'
-__version__ = '0.0.33'
+__version__ = '0.0.34'
 __author__ = 'OBGP'
+
+
+import internetarchive as ia
+from bs4 import BeautifulSoup
+from bgp.config import S3_KEYS
+from bgp.runner import Sequencer
+
+IA = ia.get_session({'s3': S3_KEYS})
+ia.get_item = IA.get_item
+
+def _memoize_xml(self):
+    if not hasattr(self, '_xml'):
+        self._xml = self.download(formats=['Djvu XML'], return_responses=True)[0].text
+    return self._xml
+
+def _memoize_plaintext(self):
+    """If converts xml to plaintext (only when needed) and memoizes result"""
+    if hasattr(self, 'xml'):
+        if not hasattr(self, '_plaintext'):
+            self._plaintext = BeautifulSoup(self.xml).text
+        return self._plaintext
+
+def upload_sequence_to_item(self, itemid, results, filename='results.json'):
+    with tempfile.NamedTemporaryFile() as tmp:
+        json.dump(results, tmp)
+        self.upload(
+            itemid, {'%s_%s' % (self.book.identifier, filename): tmp},
+            access_key=S3_KEYS.get('access'),
+            secret_key=S3_KEYS.get('secret'))
+    
+def get_book_items(self, query, rows=100, page=1):
+    """
+    :param str query: an search query for selecting/faceting books
+    :param int rows: limit how many results returned
+    :param int page: starting page to offset search results
+    :return: An `internetarchive` Item
+    :rtype: `internetarchive` Item
+    """
+    params = {'page': page, 'rows': rows, 'scope': 'all'}
+    return ia.s.search_items(query, params=params).iter_as_items()
+
+
+ia.Item.xml = property(_memoize_xml)
+ia.Item.plaintext = property(_memoize_plaintext)
+ia.Item.get_book_items = get_book_items
+ia.Item.upload_sequence_to_item = upload_sequence_to_item

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -31,7 +31,7 @@ def _memoize_plaintext(self):
     """If converts xml to plaintext (only when needed) and memoizes result"""
     if hasattr(self, 'xml'):
         if not hasattr(self, '_plaintext'):
-            self._plaintext = BeautifulSoup(self.xml).text
+            self._plaintext = BeautifulSoup(self.xml, features="lxml").text
         return self._plaintext
 
 def upload_sequence_to_item(self, itemid, results, filename='results.json'):

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -65,8 +65,7 @@ class NGramProcessor():
                 .replace('. ', ' ')
                 .replace('\n-', '')
                 .replace('\n', ' ')
-                .encode('ascii', 'ignore')
-            ) if c not in punctuation)
+            ) if str(c) not in punctuation)
         tokens = [t.strip() for t in clean(fulltext).split(' ') if t and t not in stop_words]
         return cls.tokens_to_ngrams(tokens, n=n) if n > 1 else tokens
 
@@ -81,7 +80,7 @@ class WordFreqModule:
 
     @property
     def results(self):
-        return sorted(self.freqmap.iteritems(), key=lambda (k, v): v, reverse=True)
+        return sorted(self.freqmap.iteritems(), key=lambda k, v: v, reverse=True)
 
 class ExtractorModule(object):
 

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -39,9 +39,9 @@ class NGramProcessor():
         self.n = n
         self.stop_words = stop_words
 
-    def run(self, fulltext):
+    def run(self, book):
         self.terms = self.fulltext_to_ngrams(
-            fulltext, n=self.n, stop_words=self.stop_words)
+            book.plaintext, n=self.n, stop_words=self.stop_words)
         for i, term in enumerate(self.terms):
             for m in self.modules:
                 self.modules[m].run(term, index=i)

--- a/bgp/runner.py
+++ b/bgp/runner.py
@@ -5,32 +5,28 @@ import copy
 import json
 import time
 import tempfile
-from functools import partial
-import internetarchive as ia
+
+from bgp import ia
 from bgp.config import S3_KEYS
 from bgp.modules.terms import (
     NGramProcessor, WordFreqModule, UrlExtractorModule, IsbnExtractorModule,
     STOP_WORDS
 )
+   
 
-IA = ia.get_session({'s3': S3_KEYS})
-
-def get_book_items(query, rows=100, page=1):
-    """
-    :param str query: an search query for selecting/faceting books
-    :param int rows: limit how many results returned
-    :param int page: starting page to offset search results
-    :return: An `internetarchive` Item
-    :rtype: `internetarchive` Item
-    """
-    params = {'page': page, 'rows': rows, 'scope': 'all'}
-    return IA.search_items(query, params=params).iter_as_items()
-    
 class Sequencer:
+
+    class Sequence:
+        def __init__(self, pipeline):
+            self.pipeline = pipeline
+
+        @property
+        def results(self):
+            return {p: self.pipeline[p].results for p in self.pipeline}
 
     def __init__(self, pipeline):
         self.pipeline = pipeline
-
+        
     def sequence(self, book):
         """
         :param [NGramProcessor] pipeline: a list of NGramProcessors that run modules
@@ -39,44 +35,28 @@ class Sequencer:
         :param int page: starting page to offset search results
         """
         book = book if type(book) is ia.Item else IA.get_item(book)
-        fulltext = book.download(
-            formats=['DjVuTXT'], return_responses=True)[0].text
-        sq = Sequence(copy.deepcopy(self.pipeline), book)
+        sq = self.Sequence(copy.deepcopy(self.pipeline))
         for p in sq.pipeline:
-            sq.pipeline[p].run(fulltext)
+            sq.pipeline[p].run(book)
         return sq
 
-class Sequence:
 
-    def __init__(self, pipeline, book):
-        self.book = book
-        self.pipeline = pipeline
-
-    @property
-    def results(self):
-        return {p: self.pipeline[p].results for p in self.pipeline}
-
-    def write_results_to_item(self, itemid, filename='results.json'):
-        with tempfile.NamedTemporaryFile() as tmp:
-            json.dump(self.results, tmp)
-            ia.upload(
-                itemid, {'%s_%s' % (self.book.identifier, filename): tmp},
-                access_key=S3_KEYS.get('access'),
-                secret_key=S3_KEYS.get('secret'))
+DEFAULT_SEQUENCER = Sequencer({
+    '2grams': NGramProcessor(modules={
+        'term_freq': WordFreqModule()
+    }, n=2, stop_words=STOP_WORDS),
+    '1grams': NGramProcessor(modules={
+        'term_freq': WordFreqModule(),
+        'isbns': IsbnExtractorModule(),
+        'urls': UrlExtractorModule()
+    }, n=1, stop_words=None)
+})
 
 
 def test_sequence_item(itemid):
-    s = Sequencer({
-        '2grams': NGramProcessor(modules={
-            'term_freq': WordFreqModule()
-        }, n=2, stop_words=STOP_WORDS),
-        '1grams': NGramProcessor(modules={
-            'term_freq': WordFreqModule(),
-            'isbns': IsbnExtractorModule(),
-            'urls': UrlExtractorModule()
-        }, n=1, stop_words=None)
-    })
-    return s.sequence(itemid)
+    book = ia.get_item(itemid)
+    genome = DEFAULT_SEQUENCER.sequence(book)
+    return genome
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
+beautifulsoup4==4.9.0
 internetarchive==1.9.0
-


### PR DESCRIPTION
Closes #5

BGP used to only work with a str param called `fulltext` which was limiting for modules which may have required djvu.xml (e.g. #6 for https://github.com/internetarchive/openlibrary/issues/3357)

This PR allows modules to access either xml or plaintext