### PR TITLE
Add the updated list of stop words

### DIFF
--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -6,7 +6,32 @@ from collections import defaultdict
 from lxml import etree
 
 
-STOP_WORDS = {
+STOP_WORDS = set("""'d 'll 'm 're 's 've a about above across after afterwards
+again against all almost alone along already also although always am among
+amongst amount an and another any anyhow anyone anything anyway anywhere are
+around as at back be became because become becomes becoming been before
+beforehand behind being below beside besides between beyond both bottom but by
+ca call can cannot could did do does doing done down due during each eight
+either eleven else elsewhere empty enough even ever every everyone everything
+everywhere except few fifteen fifty first five for former formerly forty four
+from front full further get give go had has have he hence her here hereafter
+hereby herein hereupon hers herself him himself his how however hundred i if
+in indeed into is it its itself just keep last latter latterly least less made
+make many may me meanwhile might mine more moreover most mostly move much must
+my myself n't name namely neither never nevertheless next nine no nobody none
+noone nor not nothing now nowhere n‘t n’t of off often on once one only onto
+or other others otherwise our ours ourselves out over own part per perhaps
+please put quite rather re really regarding same say see seem seemed seeming
+seems serious several she should show side since six sixty so some somehow
+someone something sometime sometimes somewhere still such take ten than that
+the their them themselves then thence there thereafter thereby therefore
+therein thereupon these they third this those though three through throughout
+thru thus to together too top toward towards twelve twenty two under unless
+until up upon us used using various very via was we well were what whatever
+when whence whenever where whereafter whereas whereby wherein whereupon
+wherever whether which while whither who whoever whole whom whose why will
+with within without would yet you your yours yourself yourselves ‘d ‘ll ‘m ‘re
+‘s ‘ve ’d ’ll ’m ’re ’s ’ve""".split())
     'elsewhere', 'bottom', 'n’t', 're', 'herself', 'see', 'which', 'yourself', 'top', 'somehow', 'nothing', 'move',
     'since', 'former', 'this', 'doing', 'too', 'who', 'again', 'below', 'we', 'either', 'he', 'so', 'none', 'indeed',
     'still', 'thereafter', 'also', 'empty', 'please', '‘ve', 'name', 'here', 'quite', 'no', 'afterwards', 'then',

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -6,16 +6,32 @@ from collections import defaultdict
 from lxml import etree
 
 
-STOP_WORDS = set("""a about above after again against all almost also am among an and
-    any are around as at be became because been before being below between both but by
-    can could did do does doing don down during each ever far few for from further had
-    has have having he her here hers herself him himself his how i if in into is it its
-    itself just like many may me more most much my myself new no nor not now of off
-    often on once one only or other our ours ourselves out over own s same see seems
-    she should so some such t than that the their theirs them themselves then there
-    these they things this those three through to too two under until up very was we
-    well were what when where which while who whom why will with would you your yours
-    yourself yourselves""".split())
+STOP_WORDS = {'elsewhere', 'bottom', 'n’t', 're', 'herself', 'see', 'which', 'yourself', 'top', 'somehow', 'nothing', 'move',
+              'since', 'former', 'this', 'doing', 'too', 'who', 'again', 'below', 'we', 'either', 'he', 'so', 'none', 'indeed',
+              'still', 'thereafter', 'also', 'empty', 'please', '‘ve', 'name', 'here', 'quite', 'no', 'afterwards', 'then',
+              "'s", 'down', 'its', 'full', 'nowhere', 'off', 'own', 'first', 'regarding', 'twelve', 'by', 'her', 'where', 'within',
+              'a', 'others', 'another', 'but', 'really', 'during', 'itself', 'seem', 'each', 'neither', 'three', '‘ll', 'somewhere',
+              '‘re', 'other', 'n‘t', 'rather', '’s', 'how', 'be', 'under', 'at', 'much', 'whenever', 'of', 'wherein', 'hence',
+              'are', 'my', 'everywhere', 'am', 'something', '’ll', 'twenty', 'because', 'few', 'seems', '‘d', 'through', 'your',
+              'four', 'thereby', 'into', 'has', 'could', 'our', 'out', 'if', 'already', 'namely', 'such', 'hereupon', 'therefore',
+              'why', 'back', 'some', 'whereafter', 'for', 'never', 'whom', 'two', 'there', 'me', 'however', 'anyone', 'yourselves',
+              'whereupon', 'whole', 'enough', 'on', 'unless', 'same', 'behind', 'becoming', 'than', 'sometimes', 'upon', 'often',
+              'else', 'along', 'part', 'as', 'was', 'ours', 'further', 'onto', 'until', 'amount', "'ve", 'due', 'anything', 'becomes',
+              'seeming', 'is', 'forty', 'sometime', 'around', 'once', 'beyond', 'even', 'have', 'used', 'several', '‘m', 'without',
+              'everyone', 'therein', 'whatever', 'formerly', '‘s', 'less', 'mine', 'fifteen', 'it', '’m', 'beforehand', 'from',
+              'almost', 'most', 'latterly', 'now', 'not', 'these', 'whose', 'nevertheless', 'per', 'after', 'themselves', 'via',
+              'everything', 'what', 'herein', 'show', 'whereby', 'anyhow', 'will', 'become', "'ll", 'various', 'latter', 'were',
+              'throughout', 'his', 'always', 'serious', 'must', "'d", 'in', 'meanwhile', 'before', 'keep', 'yet', 'though', 'get',
+              'hereafter', 'hereby', 'ten', 'had', 'thereupon', 'alone', 'whoever', 'one', 'across', 'side', 'over', 'or', 'besides',
+              'using', 'otherwise', 'whence', 'take', 'those', 'ever', 'eight', 'they', 'anyway', 'noone', 'an', 'many', 'moreover',
+              'third', 'himself', 'their', 'cannot', 'myself', 'i', 'call', 'been', 'hundred', 'thence', '’re', 'do', 'give', 'did',
+              'him', 'made', 'can', 'nine', 'very', 'go', 'perhaps', 'thru', 'wherever', 'although', "'m", 'became', 'above', 'hers',
+              'except', 'while', 'more', 'would', 'well', 'toward', 'might', 'only', 'to', 'the', 'you', 'say', 'about', 'yours',
+              'whether', "n't", 'among', 'least', 'nor', 'next', 'amongst', 'whither', 'ourselves', 'beside', 'them', 'whereas',
+              'put', 'and', 'towards', 'make', 'last', 'eleven', 'between', 'thus', '’ve', 'does', 'five', 'together', 'done',
+              'being', 'us', 'both', 'should', 'every', "'re", 'against', 'any', 'may', 'seemed', 'fifty', 'when', 'just', 'front',
+              '’d', 'anywhere', 'all', 'that', 'six', 'nobody', 'ca', 'with', 'sixty', 'someone', 'she', 'up', 'mostly'
+             }
 
 class NGramProcessor():
 

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -6,32 +6,33 @@ from collections import defaultdict
 from lxml import etree
 
 
-STOP_WORDS = {'elsewhere', 'bottom', 'n’t', 're', 'herself', 'see', 'which', 'yourself', 'top', 'somehow', 'nothing', 'move',
-              'since', 'former', 'this', 'doing', 'too', 'who', 'again', 'below', 'we', 'either', 'he', 'so', 'none', 'indeed',
-              'still', 'thereafter', 'also', 'empty', 'please', '‘ve', 'name', 'here', 'quite', 'no', 'afterwards', 'then',
-              "'s", 'down', 'its', 'full', 'nowhere', 'off', 'own', 'first', 'regarding', 'twelve', 'by', 'her', 'where', 'within',
-              'a', 'others', 'another', 'but', 'really', 'during', 'itself', 'seem', 'each', 'neither', 'three', '‘ll', 'somewhere',
-              '‘re', 'other', 'n‘t', 'rather', '’s', 'how', 'be', 'under', 'at', 'much', 'whenever', 'of', 'wherein', 'hence',
-              'are', 'my', 'everywhere', 'am', 'something', '’ll', 'twenty', 'because', 'few', 'seems', '‘d', 'through', 'your',
-              'four', 'thereby', 'into', 'has', 'could', 'our', 'out', 'if', 'already', 'namely', 'such', 'hereupon', 'therefore',
-              'why', 'back', 'some', 'whereafter', 'for', 'never', 'whom', 'two', 'there', 'me', 'however', 'anyone', 'yourselves',
-              'whereupon', 'whole', 'enough', 'on', 'unless', 'same', 'behind', 'becoming', 'than', 'sometimes', 'upon', 'often',
-              'else', 'along', 'part', 'as', 'was', 'ours', 'further', 'onto', 'until', 'amount', "'ve", 'due', 'anything', 'becomes',
-              'seeming', 'is', 'forty', 'sometime', 'around', 'once', 'beyond', 'even', 'have', 'used', 'several', '‘m', 'without',
-              'everyone', 'therein', 'whatever', 'formerly', '‘s', 'less', 'mine', 'fifteen', 'it', '’m', 'beforehand', 'from',
-              'almost', 'most', 'latterly', 'now', 'not', 'these', 'whose', 'nevertheless', 'per', 'after', 'themselves', 'via',
-              'everything', 'what', 'herein', 'show', 'whereby', 'anyhow', 'will', 'become', "'ll", 'various', 'latter', 'were',
-              'throughout', 'his', 'always', 'serious', 'must', "'d", 'in', 'meanwhile', 'before', 'keep', 'yet', 'though', 'get',
-              'hereafter', 'hereby', 'ten', 'had', 'thereupon', 'alone', 'whoever', 'one', 'across', 'side', 'over', 'or', 'besides',
-              'using', 'otherwise', 'whence', 'take', 'those', 'ever', 'eight', 'they', 'anyway', 'noone', 'an', 'many', 'moreover',
-              'third', 'himself', 'their', 'cannot', 'myself', 'i', 'call', 'been', 'hundred', 'thence', '’re', 'do', 'give', 'did',
-              'him', 'made', 'can', 'nine', 'very', 'go', 'perhaps', 'thru', 'wherever', 'although', "'m", 'became', 'above', 'hers',
-              'except', 'while', 'more', 'would', 'well', 'toward', 'might', 'only', 'to', 'the', 'you', 'say', 'about', 'yours',
-              'whether', "n't", 'among', 'least', 'nor', 'next', 'amongst', 'whither', 'ourselves', 'beside', 'them', 'whereas',
-              'put', 'and', 'towards', 'make', 'last', 'eleven', 'between', 'thus', '’ve', 'does', 'five', 'together', 'done',
-              'being', 'us', 'both', 'should', 'every', "'re", 'against', 'any', 'may', 'seemed', 'fifty', 'when', 'just', 'front',
-              '’d', 'anywhere', 'all', 'that', 'six', 'nobody', 'ca', 'with', 'sixty', 'someone', 'she', 'up', 'mostly'
-             }
+STOP_WORDS = {
+    'elsewhere', 'bottom', 'n’t', 're', 'herself', 'see', 'which', 'yourself', 'top', 'somehow', 'nothing', 'move',
+    'since', 'former', 'this', 'doing', 'too', 'who', 'again', 'below', 'we', 'either', 'he', 'so', 'none', 'indeed',
+    'still', 'thereafter', 'also', 'empty', 'please', '‘ve', 'name', 'here', 'quite', 'no', 'afterwards', 'then',
+    "'s", 'down', 'its', 'full', 'nowhere', 'off', 'own', 'first', 'regarding', 'twelve', 'by', 'her', 'where', 'within',
+    'a', 'others', 'another', 'but', 'really', 'during', 'itself', 'seem', 'each', 'neither', 'three', '‘ll', 'somewhere',
+    '‘re', 'other', 'n‘t', 'rather', '’s', 'how', 'be', 'under', 'at', 'much', 'whenever', 'of', 'wherein', 'hence',
+    'are', 'my', 'everywhere', 'am', 'something', '’ll', 'twenty', 'because', 'few', 'seems', '‘d', 'through', 'your',
+    'four', 'thereby', 'into', 'has', 'could', 'our', 'out', 'if', 'already', 'namely', 'such', 'hereupon', 'therefore',
+    'why', 'back', 'some', 'whereafter', 'for', 'never', 'whom', 'two', 'there', 'me', 'however', 'anyone', 'yourselves',
+    'whereupon', 'whole', 'enough', 'on', 'unless', 'same', 'behind', 'becoming', 'than', 'sometimes', 'upon', 'often',
+    'else', 'along', 'part', 'as', 'was', 'ours', 'further', 'onto', 'until', 'amount', "'ve", 'due', 'anything', 'becomes',
+    'seeming', 'is', 'forty', 'sometime', 'around', 'once', 'beyond', 'even', 'have', 'used', 'several', '‘m', 'without',
+    'everyone', 'therein', 'whatever', 'formerly', '‘s', 'less', 'mine', 'fifteen', 'it', '’m', 'beforehand', 'from',
+    'almost', 'most', 'latterly', 'now', 'not', 'these', 'whose', 'nevertheless', 'per', 'after', 'themselves', 'via',
+    'everything', 'what', 'herein', 'show', 'whereby', 'anyhow', 'will', 'become', "'ll", 'various', 'latter', 'were',
+    'throughout', 'his', 'always', 'serious', 'must', "'d", 'in', 'meanwhile', 'before', 'keep', 'yet', 'though', 'get',
+    'hereafter', 'hereby', 'ten', 'had', 'thereupon', 'alone', 'whoever', 'one', 'across', 'side', 'over', 'or', 'besides',
+    'using', 'otherwise', 'whence', 'take', 'those', 'ever', 'eight', 'they', 'anyway', 'noone', 'an', 'many', 'moreover',
+    'third', 'himself', 'their', 'cannot', 'myself', 'i', 'call', 'been', 'hundred', 'thence', '’re', 'do', 'give', 'did',
+    'him', 'made', 'can', 'nine', 'very', 'go', 'perhaps', 'thru', 'wherever', 'although', "'m", 'became', 'above', 'hers',
+    'except', 'while', 'more', 'would', 'well', 'toward', 'might', 'only', 'to', 'the', 'you', 'say', 'about', 'yours',
+    'whether', "n't", 'among', 'least', 'nor', 'next', 'amongst', 'whither', 'ourselves', 'beside', 'them', 'whereas',
+    'put', 'and', 'towards', 'make', 'last', 'eleven', 'between', 'thus', '’ve', 'does', 'five', 'together', 'done',
+    'being', 'us', 'both', 'should', 'every', "'re", 'against', 'any', 'may', 'seemed', 'fifty', 'when', 'just', 'front',
+    '’d', 'anywhere', 'all', 'that', 'six', 'nobody', 'ca', 'with', 'sixty', 'someone', 'she', 'up', 'mostly'
+    }
 
 class NGramProcessor():
 


### PR DESCRIPTION
This PR adds a total of 177 new stop words, and also removes the use of set() operation which takes unnecessary extra time complexity to convert a string into set, since ideally the STOP_WORDS variable should be a set and contain unique values.