### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -26,5 +26,5 @@ jobs:
       - run: codespell --ignore-words-list="noone" --quiet-level=2  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --profile black . || true
-      - run: pip install -r requirements.txt || true
+      - run: pip install -r requirements.txt -r requirements_test.txt || true
       - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,30 @@
+name: lint_python
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  lint_python:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.9.0-rc.1]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install black codespell flake8 isort pytest
+      - run: black --check . || true
+      # - run: black --diff . || true
+      # - if: matrix.python-version >= 3.6
+      #  run: |
+      #    pip install black
+      #    black --check . || true
+      - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --profile black . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -23,7 +23,7 @@ jobs:
       #  run: |
       #    pip install black
       #    black --check . || true
-      - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
+      - run: codespell --ignore-words-list="noone" --quiet-level=2  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --profile black . || true
       - run: pip install -r requirements.txt || true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each month, the OBGP Sequencer™ gets run against the fulltext of more than 1M 
 
 1. Please [read the whitepaper](https://docs.google.com/document/d/1eybbw_qZ3EE9CJg868BhPuq5z_36Wq2G0Ki3Lkde9v8/edit?ts=5e5edcd1#) and look through our community list of [proposed or requested modules](https://docs.google.com/document/d/1eybbw_qZ3EE9CJg868BhPuq5z_36Wq2G0Ki3Lkde9v8/edit?ts=5e5edcd1#heading=h.dj2jqsxuy8my)
 2. [Propose a "module"](https://github.com/Open-Book-Genome-Project/sequencer/issues/new) by creating a github issue
-3. Get the code: Fork this git repository and clone it to your workspace. Ceate a new branch for your module (named after its corresponding github issue number and title: e.g. `git checkout -b 12/module/find-isbns`). Install
+3. Get the code: Fork this git repository and clone it to your workspace. Create a new branch for your module (named after its corresponding github issue number and title: e.g. `git checkout -b 12/module/find-isbns`). Install
 4. [Create a new module](https://github.com/Open-Book-Genome-Project/sequencer/new/master) to the `modules/` directory
 5. Test your module locally using [Internet Archive's unrestricted collection of ~800k books](https://docs.google.com/document/d/10cNGGYrDFu0BJg-pUYYzKpjB1TWkqKspTZl2YG-yLJ4/edit?fbclid=IwAR3fx-LPu7D4zU1FbcehX2bIY1fNU_nvbqOiy5QpS0yGv_ILhVr73WHD-BI#heading=h.36kkw3g3gzos)
 5. [open a Pull Request](https://github.com/Open-Book-Genome-Project/sequencer/compare) so your contribution may be reviewed.
@@ -79,7 +79,7 @@ If your `internetarchive` tool is configured against an account with sufficient 
 >>> genome.write_results_to_item('bgp')
 ```
 
-This will upload the `genome.results` as json to <book_identifier>_results.json (e.g. `hpmor_results.json`) unless otherwise specificed by overriding params.
+This will upload the `genome.results` as json to <book_identifier>_results.json (e.g. `hpmor_results.json`) unless otherwise specified by overriding params.
 
 You will then be able to see your file `hpmor_results.json` within the `bgp` item's file downloads: https://archive.org/download/bgp
 

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -67,7 +67,7 @@ class NGramProcessor():
         """
         :param lambda modules: a dict of {'name': module}
         :param int n: n-gram sequence length
-        :param int threshold: min occurences threshold
+        :param int threshold: min occurrences threshold
         """
         self.modules = modules
         self.n = n


### PR DESCRIPTION
Output: https://github.com/cclauss/sequencer/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.