### PR TITLE
Pyupgrade and isort

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
       - run: black --check . || true
       - run: codespell --ignore-words-list="noone" --quiet-level=2  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: isort --profile black . || true
+      - run: isort --profile black .
       - run: pip install -r requirements.txt
       - run: pytest .
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
 """
     __init__.py
@@ -16,18 +15,21 @@ __author__ = 'OBGP'
 import copy
 import json
 import tempfile
+
 import internetarchive as ia
 from bs4 import BeautifulSoup
-from bgp.utils import STOP_WORDS
-from bgp.modules.terms import NGramProcessor, FulltextProcessor
-from bgp.modules.terms import (
-    WordFreqModule, UrlExtractorModule, IsbnExtractorModule,
-    ReadingLevelModule
-)
-from bgp.modules.pagetypes import PageTypeProcessor
-from bgp.modules.pagetypes import KeywordPageDetectorModule
-
 from internetarchive.config import get_config
+
+from bgp.modules.pagetypes import KeywordPageDetectorModule, PageTypeProcessor
+from bgp.modules.terms import (
+    FulltextProcessor,
+    IsbnExtractorModule,
+    NGramProcessor,
+    ReadingLevelModule,
+    UrlExtractorModule,
+    WordFreqModule,
+)
+from bgp.utils import STOP_WORDS
 
 s3_keys = get_config().get('s3')
 

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 """
     __init__.py
     ~~~~~~~~~~~

--- a/bgp/bgp_test.py
+++ b/bgp/bgp_test.py
@@ -1,6 +1,7 @@
 import unittest
 
 from bgp import ia
+
 try:  # TODO: create bgp.runner
     from bgp.runner import DEFAULT_SEQUENCER
 except ImportError:

--- a/bgp/config.py
+++ b/bgp/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
     :copyright: (c) 2020 by Open Book Genome Project

--- a/bgp/config.py
+++ b/bgp/config.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
-#-*-coding: utf-8 -*-
 
 """
     :copyright: (c) 2020 by Open Book Genome Project
     :license: BSD, see LICENSE for more details.
 """
 
+import configparser
 import os
 import sys
 import types
-import configparser
 
 path = os.path.dirname(os.path.realpath(__file__))
 approot = os.path.abspath(os.path.join(path, os.pardir))

--- a/bgp/modules/pagetypes.py
+++ b/bgp/modules/pagetypes.py
@@ -1,9 +1,9 @@
-#-*- encoding: utf-8 -*-
-
-import string
 import re
+import string
 from collections import defaultdict
+
 from lxml import etree
+
 from bgp.utils import STOP_WORDS
 
 
@@ -61,7 +61,7 @@ class WordFreqModule:
         return sorted(
             self.freqmap.items(), key=lambda k_v: k_v[0], reverse=True)
 
-class ExtractorModule(object):
+class ExtractorModule:
 
     def __init__(self, extractor):
         self.extractor = extractor
@@ -86,7 +86,7 @@ class UrlExtractorModule(ExtractorModule):
             return s
 
     def __init__(self):
-        super(UrlExtractorModule, self).__init__(self.validate_url)
+        super().__init__(self.validate_url)
 
 
 class IsbnExtractorModule(ExtractorModule):
@@ -104,7 +104,7 @@ class IsbnExtractorModule(ExtractorModule):
             return match.group()
 
     def __init__(self):
-        super(IsbnExtractorModule, self).__init__(self.validate_isbn)
+        super().__init__(self.validate_isbn)
 
 
 class PageTypeProcessor:

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -1,10 +1,8 @@
-#-*- encoding: utf-8 -*-
-
-import string
 import re
+import string
 from collections import defaultdict
-from lxml import etree
 
+from lxml import etree
 
 STOP_WORDS = set("""'d 'll 'm 're 's 've a about above across after afterwards
 again against all almost alone along already also although always am among
@@ -121,7 +119,7 @@ class WordFreqModule:
              if not self.threshold or items[1] > self.threshold],
             key=lambda k_v: k_v[0], reverse=True)
 
-class ExtractorModule(object):
+class ExtractorModule:
 
     def __init__(self, extractor):
         self.extractor = extractor
@@ -146,7 +144,7 @@ class UrlExtractorModule(ExtractorModule):
             return s
 
     def __init__(self):
-        super(UrlExtractorModule, self).__init__(self.validate_url)
+        super().__init__(self.validate_url)
 
 
 class IsbnExtractorModule(ExtractorModule):
@@ -164,7 +162,7 @@ class IsbnExtractorModule(ExtractorModule):
             return match.group()
 
     def __init__(self):
-        super(IsbnExtractorModule, self).__init__(self.validate_isbn)
+        super().__init__(self.validate_isbn)
 
 
 class PageTypeProcessor:

--- a/bgp/utils.py
+++ b/bgp/utils.py
@@ -1,4 +1,3 @@
-
 STOP_WORDS = set("""a about above after again against all almost also am among an and
     any are around as at be became because been before being below between both but by
     can could did do does doing don down during each ever far few for from further had

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 OBGP: Open Book Genome Project
 """
@@ -7,6 +5,7 @@ OBGP: Open Book Genome Project
 import codecs
 import os
 import re
+
 import setuptools
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -31,7 +30,7 @@ def find_version(*file_paths):
 def requirements():
     """Returns requirements.txt as a list usable by setuptools"""
     import os
-    reqtxt = os.path.join(here, u'requirements.txt')
+    reqtxt = os.path.join(here, 'requirements.txt')
     with open(reqtxt) as f:
         return f.read().split()
                             


### PR DESCRIPTION
[isort](https://github.com/PyCQA/isort) the imports with `isort --profile black .` and [pyupgrade](https://github.com/asottile/pyupgrade) to modern idioms with `pyupgrade --py36-plus **/*.py` and modify our GitHub Action to enforce the same.