### PR TITLE
argparse is built into the Python standard library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,4 @@ setuptools.setup(
     classifiers=[
         "License :: OSI Approved :: MIT License",
         ],
-    extras_require={
-        ':python_version=="2.7"': ['argparse']
-        }
 )


### PR DESCRIPTION
Py27 docs: https://docs.python.org/2.7/library/argparse.html