### PR TITLE
Closes #37 Plaintext downloaded from IA instead of derived from xml

### DIFF
--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -50,7 +50,7 @@ def _memoize_plaintext(self):
     _memoize_plaintext_tic = time.perf_counter()
     if hasattr(self, 'xml'):
         if not hasattr(self, '_plaintext'):
-            self._plaintext = BeautifulSoup(self.xml, features="lxml").text
+            self._plaintext = self.download(formats=['DjVuTXT'], return_responses=True)[0].text
         _memoize_plaintext_toc = time.perf_counter()
         _memoize_plaintext_time = round(_memoize_plaintext_toc - _memoize_plaintext_tic, 3)
         print(f"_memoize_plaintext took {_memoize_plaintext_time} seconds to complete.")


### PR DESCRIPTION
Getting plaintext appears to be around 10x faster and doesn't change genome result except for reading level which now tends to be much higher. Reading completes much faster, probably prematurely. Probably related to downloaded plaintext not having newlines for each word.

Timings when derived from xml:

```
ghostseer01schiuoft:  - success
_memoize_xml took 2.426 seconds to complete.
_memoize_xml took 0.0 seconds to complete.
_memoize_plaintext took 19.164 seconds to complete.
fulltext_to_ngrams took 0.532 seconds to complete.
_memoize_xml took 0.0 seconds to complete.
_memoize_plaintext took 0.0 seconds to complete.
fulltext_to_ngrams took 0.613 seconds to complete.
_memoize_xml took 0.0 seconds to complete.
_memoize_plaintext took 0.0 seconds to complete.
_memoize_xml took 0.0 seconds to complete.
sequence took 130.907 seconds to complete.
```

Timings when downloaded from IA Djvu TXT:

```
ghostseer01schiuoft:  - success
_memoize_xml took 1.283 seconds to complete.
ghostseer01schiuoft:  - success
_memoize_plaintext took 2.151 seconds to complete.
fulltext_to_ngrams took 0.39 seconds to complete.
_memoize_xml took 0.0 seconds to complete.
_memoize_plaintext took 0.0 seconds to complete.
fulltext_to_ngrams took 0.4 seconds to complete.
_memoize_xml took 0.0 seconds to complete.
_memoize_plaintext took 0.0 seconds to complete.
_memoize_xml took 0.0 seconds to complete.
sequence took 8.182 seconds to complete.
```