### PR TITLE
Create Pipeline

### DIFF
--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -123,7 +123,7 @@ class Sequencer:
         def upload(self, itemid=None, results=None):
             if not results:
                 results = self.results
-            itemid = itemid or self.book.identifier or results['identifier']
+            itemid = itemid or results['identifier']
             with tempfile.NamedTemporaryFile() as tmp:
                 tmp.write(json.dumps(results).encode())
                 tmp.flush()

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -120,16 +120,8 @@ class Sequencer:
                 with open(item_path + 'book_genome.json', 'w') as txt:
                     txt.write(json.dumps(self.results))
 
-        def upload(self, itemid=None, results=None):
-            if not results:
-                results = self.results
-            itemid = itemid or results['identifier']
-            with tempfile.NamedTemporaryFile() as tmp:
-                tmp.write(json.dumps(results).encode())
-                tmp.flush()
-                ia.upload(itemid, {'book_genome.json': tmp},
-                          access_key=s3_keys['access'],
-                          secret_key=s3_keys['secret'])
+        def upload(self):
+            Sequencer._upload(results=self.results)
 
         @property
         def results(self):
@@ -183,6 +175,16 @@ class Sequencer:
         except requests.exceptions.HTTPError:
             raise Exception(sq.book.identifier + ' - DjvuXML and/or DjvuTXT is forbidden and can\'t be sequenced!')
             logging.error(sq.book.identifier + ' - DjvuXML and/or DjvuTXT is forbidden and can\'t be sequenced!')
+
+    @classmethod
+    def _upload(cls, itemid=None, results=None):
+        itemid = itemid or results['identifier']
+        with tempfile.NamedTemporaryFile() as tmp:
+            tmp.write(json.dumps(results).encode())
+            tmp.flush()
+            ia.upload(itemid, {'book_genome.json': tmp},
+                      access_key=s3_keys['access'],
+                      secret_key=s3_keys['secret'])
 
 DEFAULT_SEQUENCER = Sequencer({
     '2grams': NGramProcessor(modules={

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -177,8 +177,8 @@ class Sequencer:
             logging.error(sq.book.identifier + ' - DjvuXML and/or DjvuTXT is forbidden and can\'t be sequenced!')
 
     @classmethod
-    def _upload(cls, itemid=None, results=None):
-        itemid = itemid or results['identifier']
+    def _upload(cls, results=None):
+        itemid = results.get('identifier')
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(json.dumps(results).encode())
             tmp.flush()

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -120,15 +120,16 @@ class Sequencer:
                 with open(item_path + 'book_genome.json', 'w') as txt:
                     txt.write(json.dumps(self.results))
 
-        def upload(self, itemid=None):
-            if getattr(self, 'book'):
-                itemid = itemid or self.book.identifier
-                with tempfile.NamedTemporaryFile() as tmp:
-                    tmp.write(json.dumps(self.results).encode())
-                    tmp.flush()
-                    ia.upload(itemid, {'%s_genome.json' % (itemid): tmp},
-                              access_key=s3_keys['access'],
-                              secret_key=s3_keys['secret'])
+        def upload(self, itemid=None, results=None):
+            if not results:
+                results = self.results
+            itemid = itemid or self.book.identifier or results['identifier']
+            with tempfile.NamedTemporaryFile() as tmp:
+                tmp.write(json.dumps(results).encode())
+                tmp.flush()
+                ia.upload(itemid, {'%s_genome.json' % (itemid): tmp},
+                          access_key=s3_keys['access'],
+                          secret_key=s3_keys['secret'])
 
         @property
         def results(self):

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -112,11 +112,12 @@ class Sequencer:
             self.total_time = 0
 
         def save(self, path=''):
+            item_path = path + self.book.identifier + '/'
             # trailing slash needed for path
             if getattr(self, 'book'):
-                if path and not os.path.exists(path):
-                    os.makedirs(path)
-                with open(path + self.book.identifier + '_genome.json', 'w') as txt:
+                if item_path and not os.path.exists(item_path):
+                    os.makedirs(item_path)
+                with open(item_path + 'book_genome.json', 'w') as txt:
                     txt.write(json.dumps(self.results))
 
         def upload(self, itemid=None):
@@ -132,7 +133,7 @@ class Sequencer:
         def modify_metadata(self, metadata, itemid=None):
             if getattr(self, 'book'):
                 itemid = itemid or self.book.identifier
-                ia.modify_metadata(itemid, metadata)
+                return ia.modify_metadata(itemid, metadata)
 
         @property
         def results(self):

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -98,14 +98,6 @@ def get_software_version():  # -> str:
     cmd = "git rev-parse --short HEAD --".split()
     return str(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.read().decode().strip())
 
-def modify_metadata(itemid, metadata):
-    return ia.modify_metadata(itemid, metadata)
-
-def item_metdata(itemid):
-    item = ia.get_item(itemid)
-    metadata = item.item_metadata
-    return metadata
-
 
 ia.get_book_items = get_book_items
 ia.Item.xml = property(_memoize_xml)

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -127,7 +127,7 @@ class Sequencer:
             with tempfile.NamedTemporaryFile() as tmp:
                 tmp.write(json.dumps(results).encode())
                 tmp.flush()
-                ia.upload(itemid, {'%s_genome.json' % (itemid): tmp},
+                ia.upload(itemid, {'book_genome.json': tmp},
                           access_key=s3_keys['access'],
                           secret_key=s3_keys['secret'])
 

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -98,6 +98,14 @@ def get_software_version():  # -> str:
     cmd = "git rev-parse --short HEAD --".split()
     return str(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.read().decode().strip())
 
+def modify_metadata(itemid, metadata):
+    return ia.modify_metadata(itemid, metadata)
+
+def item_metdata(itemid):
+    item = ia.get_item(itemid)
+    metadata = item.item_metadata
+    return metadata
+
 
 ia.get_book_items = get_book_items
 ia.Item.xml = property(_memoize_xml)
@@ -129,11 +137,6 @@ class Sequencer:
                     ia.upload(itemid, {'%s_genome.json' % (itemid): tmp},
                               access_key=s3_keys['access'],
                               secret_key=s3_keys['secret'])
-
-        def modify_metadata(self, metadata, itemid=None):
-            if getattr(self, 'book'):
-                itemid = itemid or self.book.identifier
-                return ia.modify_metadata(itemid, metadata)
 
         @property
         def results(self):

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -129,6 +129,11 @@ class Sequencer:
                               access_key=s3_keys['access'],
                               secret_key=s3_keys['secret'])
 
+        def modify_metadata(self, metadata, itemid=None):
+            if getattr(self, 'book'):
+                itemid = itemid or self.book.identifier
+                ia.modify_metadata(itemid, metadata)
+
         @property
         def results(self):
             data = {p: self.pipeline[p].results for p in self.pipeline}

--- a/bgp/__init__.py
+++ b/bgp/__init__.py
@@ -207,3 +207,17 @@ DEFAULT_SEQUENCER = Sequencer({
         'backpage_isbn': BackpageIsbnExtractorModule()
     })
 })
+
+MINIMAL_SEQUENCER = Sequencer({
+    '2grams': NGramProcessor(modules={
+        'term_freq': WordFreqModule()
+    }, n=2, threshold=2, stop_words=STOP_WORDS),
+    '1grams': NGramProcessor(modules={
+        'term_freq': WordFreqModule(),
+        'urls': UrlExtractorModule()
+    }, n=1, stop_words=None),
+    'pagetypes': PageTypeProcessor(modules={
+        'copyright_page': CopyrightPageDetectorModule(),
+        'backpage_isbn': BackpageIsbnExtractorModule()
+    })
+})

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -321,7 +321,7 @@ class KeywordPageDetectorModule:
         if not self.match_limit or len(self.matched_pages) < self.match_limit:
             for word in page.iter('WORD'):
                 if word.text.lower() in self.keywords:
-                    param = page[0].attrib['value'].split('.')[0]
+                    param = page[0].attrib['value'].split('.djvu')[0]
                     current_page = param[-4:]
                     match = {
                         'page': current_page,
@@ -359,9 +359,9 @@ class BackpageIsbnExtractorModule():
         self.isbns = []
 
     def run(self, page, node):
-        current_page = int(page[0].attrib['value'].split('.')[0][-4:])
+        current_page = int(page[0].attrib['value'].split('.djvu')[0][-4:])
         if not hasattr(self, 'last_page'):
-            self.last_page = int(node.xpath("//OBJECT")[-1][0].attrib['value'].split('.')[0][-4:])
+            self.last_page = int(node.xpath("//OBJECT")[-1][0].attrib['value'].split('.djvu')[0][-4:])
         if current_page == self.last_page:
             self.isbns = IsbnExtractorModule.extract_isbn(page)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,20 @@
+import os
+import json
+
+RESULTS_PATH = 'results/bgp_results/'
+books = [doc['identifier'] for doc in json.load(open('2021-06-16-obgp_ids.json'))]
+done_books = set([iaid.split('_genome.json')[0] for iaid in os.listdir(RESULTS_PATH)])
+
+from bgp import ia, DEFAULT_SEQUENCER
+with open('run.log', 'a') as fout:
+    for book in books:
+        if book in done_books:
+            print("Skipping: %s\n" % book)
+        else:
+            try:
+                result = DEFAULT_SEQUENCER.sequence(book)
+                if result:
+                    fout.write("Success: %s\n" % book)
+                    result.save(path=RESULTS_PATH)
+            except:
+                fout.write("Failure: %s\n" % book)

--- a/pipeline.py
+++ b/pipeline.py
@@ -10,8 +10,6 @@ from bgp import ia, DEFAULT_SEQUENCER
 # Each function should be idempotent. What steps are there for each item. Program should be able to resume from any point of failure. If run multiple times won’t cause issues.
 # Add documentation to pipeline to make more readable
 # For db_* functions, if conflicting record exists, remove.
-# Make sure that update_isbn c_isbns and b_isbns are ok if all empty.
-# Separate function for get canonical isbn
 
 # Hit OL for ISBN info and save in folder
 # Look into sqlite3
@@ -75,8 +73,12 @@ def db_urls_found(identifier, urls):
 
 
 def get_canonical_isbn(result):
-    c_isbns = result.results['pagetypes']['modules']['copyright_page']['results'][0]['isbns']
-    b_isbns = result.results['pagetypes']['modules']['backpage_isbn']['results']
+    c_isbns = None
+    b_isbns = None
+    if any(result.results['pagetypes']['modules']['copyright_page']['results']):
+        c_isbns = result.results['pagetypes']['modules']['copyright_page']['results'][0]['isbns']
+    if any(result.results['pagetypes']['modules']['backpage_isbn']['results']):
+        b_isbns = result.results['pagetypes']['modules']['backpage_isbn']['results']
 
     if c_isbns and b_isbns:
         return [x for x in c_isbns if x in b_isbns][0]
@@ -84,6 +86,8 @@ def get_canonical_isbn(result):
         return b_isbns[-1]
     elif c_isbns:
         return c_isbns[0]
+    else:
+        return None
 
 
 def update_isbn(result):

--- a/pipeline.py
+++ b/pipeline.py
@@ -8,10 +8,6 @@ import traceback
 
 from bgp import MINIMAL_SEQUENCER, ia
 
-# TODO
-# Hit OL for ISBN info and save in folder
-# Look into sqlite3
-
 parser = argparse.ArgumentParser(prog='[pipeline]',
                                  description='Automate Open Book Genome Project sequencer')
 
@@ -122,7 +118,7 @@ def update_isbn(genome):
     Considers any ISBN-like identifiers extracted from the book's sequenced genome
     in order to identify a canonical ISBN for this books.
     """
-    itemid = genome['identifier']
+    itemid = genome.get('identifier')
     # Checks if ia item already has isbn
     item = ia.get_item(itemid)
     metadata = item.item_metadata['metadata']
@@ -151,7 +147,7 @@ def extract_urls(genome):
     """
     Save item's extracted urls to database.
     """
-    itemid = genome['identifier']
+    itemid = genome.get('identifier')
     urls = set([url for url in genome['1grams']['modules']['urls']['results'] if 'archive.org' not in url])
     db_urls_found(itemid, urls)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -5,7 +5,7 @@ import os
 import sys
 import traceback
 
-from bgp import MINIMAL_SEQUENCER, modify_metadata, item_metdata
+from bgp import MINIMAL_SEQUENCER, ia
 
 # TODO
 # Hit OL for ISBN info and save in folder
@@ -105,9 +105,10 @@ def update_isbn(genome):
     """
     itemid = genome['identifier']
     # Checks if ia item already has isbn
-    metadata = item_metdata(itemid)['metadata']
+    item = ia.get_item(itemid)
+    metadata = item.item_metadata['metadata']
     if 'isbn' in metadata:
-        item_isbn = item_metdata(itemid)['metadata']['isbn'][0]
+        item_isbn = item.item_metadata['metadata']['isbn'][0]
     else:
         item_isbn = False
     genome_isbn = get_canonical_isbn(genome)
@@ -115,8 +116,7 @@ def update_isbn(genome):
         db_isbn_extracted(itemid, genome_isbn)
         if not item_isbn:
             try:
-                pass
-                update = modify_metadata(itemid, dict(isbn=genome_isbn))
+                update = item.modify_metadata(dict(isbn=genome_isbn))
                 if update.status_code == 200:
                     db_update_succeed(itemid)
             except Exception as e:

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,11 +1,38 @@
-import os
+import argparse
 import json
+import os
+import sys
 
 from bgp import ia, DEFAULT_SEQUENCER
 
+# TODO
+# Make identifiers file passed as param
+# Switch to 1 folder per book
+# genome named book_genome.json
+# Make functions for UPLOADED, ISBN_ADDED, DATE_ADDED
+# Hit OL for ISBN info and save in folder
+# Create test ia items
+# Look into sqlite3
+
+parser = argparse.ArgumentParser(prog='[pipeline]',
+                                 description='Automate Open Book Genome Project sequencer')
+
+parser.add_argument('Path',
+                    metavar='source-path',
+                    type=str,
+                    help='path to the jsonl file with ia identifiers')
+
+args = parser.parse_args()
+
+input_path = args.Path
+
+if not os.path.isfile(input_path):
+    print('The path specified does not exist')
+    sys.exit()
+
 RESULTS_PATH = 'results/bgp_results/'
 books = []
-with open('2021-06-16-obgp_ids.jsonl') as fin:
+with open(input_path) as fin:
     for line in fin:
         books.append(json.loads(line.replace("\n", ""))['identifier'])
 done_books = set([iaid.split('_genome.json')[0] for iaid in os.listdir(RESULTS_PATH)])

--- a/pipeline.py
+++ b/pipeline.py
@@ -7,8 +7,6 @@ import traceback
 
 from bgp import MINIMAL_SEQUENCER, ia
 
-import bgp
-
 # TODO
 # Hit OL for ISBN info and save in folder
 # Look into sqlite3
@@ -162,6 +160,8 @@ with open('run.log', 'a') as fout:
             if not os.path.exists('{}{}/book_genome.json'.format(RESULTS_PATH, book)):
                 result = MINIMAL_SEQUENCER.sequence(book)
                 result.save(path=RESULTS_PATH)
+                result.upload()
+                db_genome_updated(book)
             f = open('{}{}/book_genome.json'.format(RESULTS_PATH, book),)
             genome = json.load(f)
             update_failed = os.path.exists('{}{}/UPDATE_FAILED_{}'.format(RESULTS_PATH, book, book))
@@ -171,10 +171,7 @@ with open('run.log', 'a') as fout:
             if not glob.glob('{}{}/URLS_*'.format(RESULTS_PATH, book)):
                 extract_urls(genome)
             if not os.path.exists('{}{}/GENOME_UPDATED_{}'.format(RESULTS_PATH, book, book)):
-                try:
-                    result.upload(results=genome)
-                except NameError:
-                    bgp.Sequencer.Sequence.upload(self=None, results=genome)
+                MINIMAL_SEQUENCER._upload(results=genome)
                 db_genome_updated(book)
             db_sequence_success(book)
         except Exception:

--- a/pipeline.py
+++ b/pipeline.py
@@ -155,15 +155,18 @@ if RESULTS_PATH and not os.path.exists(RESULTS_PATH):
 with open('run.log', 'a') as fout:
     for book in books:
         try:
+            genome = None
             if not os.path.exists('{}{}/'.format(RESULTS_PATH, book)):
                 os.makedirs('{}{}/'.format(RESULTS_PATH, book))
             if not os.path.exists('{}{}/book_genome.json'.format(RESULTS_PATH, book)):
-                result = MINIMAL_SEQUENCER.sequence(book)
-                result.save(path=RESULTS_PATH)
-                result.upload()
+                genome = MINIMAL_SEQUENCER.sequence(book)
+                genome.save(path=RESULTS_PATH)
+                genome.upload()
                 db_genome_updated(book)
-            f = open('{}{}/book_genome.json'.format(RESULTS_PATH, book),)
-            genome = json.load(f)
+            if not genome:
+                # Get genome from file if not in memory
+                f = open('{}{}/book_genome.json'.format(RESULTS_PATH, book),)
+                genome = json.load(f)
             update_failed = os.path.exists('{}{}/UPDATE_FAILED_{}'.format(RESULTS_PATH, book, book))
             isbn_attempted = glob.glob('{}{}/ISBN_*'.format(RESULTS_PATH, book))
             if update_failed or not isbn_attempted:

--- a/pipeline.py
+++ b/pipeline.py
@@ -71,6 +71,10 @@ def db_urls_found(identifier, urls):
     touch(identifier, 'URLS_{}'.format(urls_count), data=urls_data)
 
 
+def db_genome_updated(identifier):
+    touch(identifier, 'GENOME_UPDATED')
+
+
 def db_sequence_success(identifier):
     if os.path.exists('{}{}/SEQUENCE_FAILURE_{}'.format(RESULTS_PATH, identifier, identifier)):
         os.remove('{}{}/SEQUENCE_FAILURE_{}'.format(RESULTS_PATH, identifier, identifier))
@@ -159,6 +163,9 @@ with open('run.log', 'a') as fout:
                 update_isbn(genome)
             if not glob.glob('{}{}/URLS_*'.format(RESULTS_PATH, book)):
                 extract_urls(genome)
+            if not os.path.exists('{}{}/GENOME_UPDATED_{}'.format(RESULTS_PATH, book, book)):
+                result.upload(results=genome)
+                db_genome_updated(book)
             db_sequence_success(book)
         except Exception:
             e = traceback.format_exc()

--- a/pipeline.py
+++ b/pipeline.py
@@ -135,9 +135,7 @@ if RESULTS_PATH and not os.path.exists(RESULTS_PATH):
 
 with open('run.log', 'a') as fout:
     for book in books:
-        # done_books is redefined for each book because new books may have been added since sequence began
-        done_books = set([iaid for iaid in os.listdir(RESULTS_PATH)])
-        if book in done_books:
+        if book in os.listdir(RESULTS_PATH):
             print("Skipping: {}\n".format(book))
         else:
             try:

--- a/pipeline.py
+++ b/pipeline.py
@@ -6,12 +6,9 @@ import sys
 from bgp import ia, DEFAULT_SEQUENCER
 
 # TODO
-# Make identifiers file passed as param
 # Switch to 1 folder per book
 # genome named book_genome.json
-# Make functions for UPLOADED, ISBN_ADDED, DATE_ADDED
 # Hit OL for ISBN info and save in folder
-# Create test ia items
 # Look into sqlite3
 
 parser = argparse.ArgumentParser(prog='[pipeline]',
@@ -32,6 +29,60 @@ if not os.path.isfile(input_path):
 
 RESULTS_PATH = 'results/bgp_results/'
 books = []
+
+
+def touch(identifier, record):
+    file_name = '{}{}/{}_{}'.format(RESULTS_PATH, identifier, record, identifier)
+    if os.path.exists(file_name):
+        raise Exception('DatabaseRecordConflict')
+    else:
+        open(file_name, 'a').close()
+
+
+def db_isbn_extracted(identifier, isbn):
+    touch(identifier, 'ISBN_{}'.format(isbn))
+
+
+def db_isbn_none(identifier):
+    touch(identifier, 'UPDATE_NONE')
+
+
+def db_update_failed(identifier):
+    touch(identifier, 'UPDATE_FAILED')
+
+
+def db_update_succeed(identifier):
+    touch(identifier, 'UPDATE_SUCCEED')
+
+
+def db_update_conflict(identifier):
+    touch(identifier, 'UPDATE_CONFLICT')
+
+
+def update_isbn(result):
+    itemid = result.book.identifer
+    item_isbn = 'isbn' in result.book.metadata and result.book.metadata['isbn'][0]
+    c_isbns = result.results['pagetypes']['modules']['copyright_page']['results'][0]['isbns']
+    b_isbns = result.results['pagetypes']['modules']['backpage_isbn']['results']
+
+    if c_isbns and b_isbns:
+        genome_isbn = [x for x in c_isbns if x in b_isbns]
+    elif b_isbns:
+        genome_isbn = [b_isbns[-1]]
+    elif c_isbns:
+        genome_isbn = [c_isbns[0]]
+
+    if genome_isbn:
+        db_isbn_extracted(itemid, genome_isbn)
+        if not genome_isbn == item_isbn:
+            update = result.modify_metadata(dict(isbn=genome_isbn))
+            if update.status_code == 200:
+                db_update_succeed(itemid)
+            else: db_update_failed(itemid)
+        else: db_update_conflict(itemid)
+    else: db_isbn_none(itemid)
+
+
 with open(input_path) as fin:
     for line in fin:
         books.append(json.loads(line.replace("\n", ""))['identifier'])
@@ -47,6 +98,7 @@ with open('run.log', 'a') as fout:
                 if result:
                     fout.write("Success: {}\n".format(book))
                     result.save(path=RESULTS_PATH)
+                    update_isbn(result)
             except Exception as e:
                 fout.write("Failure: {} | {}\n".format(book, e))
         # Force log writing to disk from memory for each book

--- a/pipeline.py
+++ b/pipeline.py
@@ -91,15 +91,20 @@ def get_canonical_isbn(genome):
     c_isbns = None
     b_isbns = None
     if genome['pagetypes']['modules']['copyright_page']['results']:
+        # ISBN's extracted from copyright page
         c_isbns = genome['pagetypes']['modules']['copyright_page']['results'][0]['isbns']
     if genome['pagetypes']['modules']['backpage_isbn']['results']:
+        # ISBN's extracted from back page
         b_isbns = genome['pagetypes']['modules']['backpage_isbn']['results']
 
     if c_isbns and b_isbns and any(x in c_isbns for x in b_isbns):
+        # Return matching ISBN from copyright page and back page
         return [x for x in c_isbns if x in b_isbns][0]
     elif c_isbns:
+        # Return first ISBN on copyright page
         return c_isbns[0]
     elif b_isbns:
+        # Return last isbn on back page
         return b_isbns[-1]
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,20 +1,26 @@
 import os
 import json
 
+from bgp import ia, DEFAULT_SEQUENCER
+
 RESULTS_PATH = 'results/bgp_results/'
-books = [doc['identifier'] for doc in json.load(open('2021-06-16-obgp_ids.json'))]
+books = []
+with open('2021-06-16-obgp_ids.jsonl') as fin:
+    for line in fin:
+        books.append(json.loads(line.replace("\n", ""))['identifier'])
 done_books = set([iaid.split('_genome.json')[0] for iaid in os.listdir(RESULTS_PATH)])
 
-from bgp import ia, DEFAULT_SEQUENCER
 with open('run.log', 'a') as fout:
     for book in books:
         if book in done_books:
-            print("Skipping: %s\n" % book)
+            print("Skipping: {}\n".format(book))
         else:
             try:
                 result = DEFAULT_SEQUENCER.sequence(book)
                 if result:
-                    fout.write("Success: %s\n" % book)
+                    fout.write("Success: {}\n".format(book))
                     result.save(path=RESULTS_PATH)
-            except:
-                fout.write("Failure: %s\n" % book)
+            except Exception as e:
+                fout.write("Failure: {} | {}\n".format(book, e))
+        # Force log writing to disk from memory for each book
+        fout.flush()

--- a/pipeline.py
+++ b/pipeline.py
@@ -7,6 +7,8 @@ import traceback
 
 from bgp import MINIMAL_SEQUENCER, ia
 
+import bgp
+
 # TODO
 # Hit OL for ISBN info and save in folder
 # Look into sqlite3
@@ -164,7 +166,10 @@ with open('run.log', 'a') as fout:
             if not glob.glob('{}{}/URLS_*'.format(RESULTS_PATH, book)):
                 extract_urls(genome)
             if not os.path.exists('{}{}/GENOME_UPDATED_{}'.format(RESULTS_PATH, book, book)):
-                result.upload(results=genome)
+                try:
+                    result.upload(results=genome)
+                except NameError:
+                    bgp.Sequencer.Sequence.upload(self=None, results=genome)
                 db_genome_updated(book)
             db_sequence_success(book)
         except Exception:

--- a/pipeline.py
+++ b/pipeline.py
@@ -100,6 +100,11 @@ def get_canonical_isbn(genome):
 
 
 def update_isbn(genome):
+    """
+    Updates the Archive.org metadata for an item to add missing ISBN when possible.
+    Considers any ISBN-like identifiers extracted from the book's sequenced genome
+    in order to identify a canonical ISBN for this books.
+    """
     itemid = genome['identifier']
     # Checks if ia item already has isbn
     metadata = item_metdata(itemid)['metadata']
@@ -125,6 +130,9 @@ def update_isbn(genome):
 
 
 def extract_urls(genome):
+    """
+    Save item's extracted urls to database.
+    """
     itemid = genome['identifier']
     urls = set([url for url in genome['1grams']['modules']['urls']['results'] if 'archive.org' not in url])
     db_urls_found(itemid, urls)


### PR DESCRIPTION
This pipeline allows a user to sequence a list of books from a jsonl in the following format:

```jsonl
{"identifier": "samplebook"}
{"identifier": "9780262517638OpenAccess"}
```

The pipeline then automatically chooses the most probable isbn for the book and attempts to update ia metadata accordingly while keeping a filesystem based database of all these actions.


|Record|Filesystem Action|
| ---- | ---- |
| How do we determine which books we've successfully uploaded a genome     | Touches `GENOME_UPDATED_{identifier}`    |
| How do we determine the ISBNs of all books we’ve sequenced so far    | Touches `ISBN_1234567890_{identifier}`    |
| How do we determine which books were sequenced but had no ISBN     | Touches `UPDATE_NONE_{identifier}`    |
| How do we know which books attempted updating but failed     | `UPDATE_FAILED_{identifier}`     |
| How do we know which books succeeded at updating and succeed     | `UPDATE_SUCCEEDED_{identifier}`     |
| How do we know if item already has isbn metadata and is skipped     | `UPDATE_CONFLICT_{identifier}`     |
| How do we know how many new urls were found in a book     | `URLS_{number_of_urls}_{identifier}`     |

The user can can grep and pipe to wc -l which tells them how many for each status and lists those items


### Example Usage

Here is a archive item with the identifier `samplebook`. It has an isbn in the text of the book but no isbn metadata.

<img width="638" alt="Screen Shot 2021-07-15 at 6 06 08 PM" src="https://user-images.githubusercontent.com/6785029/125876309-efed1316-96a2-47fb-a874-77169be15529.png">

There is a jsonl file with the items to be sequenced listed on new lines.

```jsonl
{"identifier": "samplebook"}
{"identifier": "9780262517638OpenAccess"}
```

To use the pipeline, run `python pipeline.py samplebook.jsonl`

You can specify the amount of pipeline processes to run concurrently with `--p {number of processes}` as a parameter. For example: `python pipeline.py --p 4 samplebook.jsonl`

If we `tree results/bgp_results` now we get:

```
results/bgp_results
├── 9780262517638OpenAccess
│   ├── ISBN_9780262517638_9780262517638OpenAccess
│   ├── UPDATE_CONFLICT_9780262517638OpenAccess
│   ├── URLS_290_9780262517638OpenAccess
│   └── book_genome.json
└── samplebook
    ├── ISBN_0787959529_samplebook
    ├── UPDATE_SUCCEED_samplebook
    ├── URLS_0_samplebook
    └── book_genome.json

2 directories, 8 files
```

If we check the metadata for the book on archive.org again we can see that the isbn field has been updated.

<img width="638" alt="Screen Shot 2021-07-15 at 6 06 08 PM" src="https://user-images.githubusercontent.com/6785029/125876475-976495e1-05ac-465d-bac6-6fd8fe9ca5cb.png">

There is also a file generated named `URLS_0_samplebook` which indicates that 0 non 'archive.org' were extracted.

In the case of another item like `9780262517638OpenAccess`, the filename indicates that 290 new urls were extracted. If we look at the contents of that file we will see all the unique urls extracted separated by newlines.

```
http://blogs.law.harvard.edu/pamphlet/2009/05/29/what-percentage
http://www.sherpa.ac.uk/romeo
http://www.library.yale.edu/~llicense/listarchives/0405/msg00038
http://dash.harvard.edu/bitstream/handle/l/4552050/suber_nofee
http://dx.doi.org/10.1371/journal.pone.0013636
http://doctorrw.blogspot.com/2007/05/tabloid-based-medicine
... etc.
```

The `9780262517638OpenAccess` directory also shows that a url was extracted with the `ISBN_9780262517638_9780262517638OpenAccess` record, but was the ia item was not updated because a isbn already existed with the `UPDATE_CONFLICT_9780262517638OpenAccess`