### PR TITLE
Table of Contents Page detection Draft

### DIFF
--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -356,7 +356,7 @@ class CopyrightPageDetectorModule(KeywordPageDetectorModule):
 class TocPageDetectorModule(KeywordPageDetectorModule):
 
     def __init__(self):
-        super().__init__(['contents', 'table of contents', "table of content"], match_limit=1)
+        super().__init__(["table of content"], match_limit=1)
 
     def detectTocHeading(self, page):
         for line in page.iter('LINE'):

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -356,8 +356,28 @@ class CopyrightPageDetectorModule(KeywordPageDetectorModule):
 class TocPageDetectorModule(KeywordPageDetectorModule):
 
     def __init__(self):
-        super().__init__(['contents', 'table of contents'], match_limit=1)
+        super().__init__(['contents', 'table of contents', "table of content"], match_limit=1)
 
+    def detectTocHeading(self, page):
+        for line in page.iter('LINE'):
+            heading = ""
+            for word in line.iter('WORD'):
+                heading = heading + " " + word.text
+            if heading.lower().strip() in self.keywords:
+                return True
+        
+        return False
+
+
+    def run(self, page, node):
+        if not self.match_limit or len(self.matched_pages) < self.match_limit:
+            if self.detectTocHeading(page):
+                param = page[0].attrib['value'].split('.djvu')[0]
+                current_page = param[-4:]
+                match = {
+                    'page': current_page,
+                }
+                self.matched_pages.append(match)
 
 class BackpageIsbnExtractorModule():
 

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -353,6 +353,12 @@ class CopyrightPageDetectorModule(KeywordPageDetectorModule):
         super().__init__(['copyright', '©'], extractor=self.extractor, match_limit=1)
 
 
+class TocPageDetectorModule(KeywordPageDetectorModule):
+
+    def __init__(self):
+        super().__init__(['contents', 'table of contents'], match_limit=1)
+
+
 class BackpageIsbnExtractorModule():
 
     def __init__(self):

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -356,7 +356,7 @@ class CopyrightPageDetectorModule(KeywordPageDetectorModule):
 class TocPageDetectorModule(KeywordPageDetectorModule):
 
     def __init__(self):
-        super().__init__(["table of content"], match_limit=1)
+        super().__init__(["table of contents"], match_limit=1)
 
     def detectTocHeading(self, page):
         for i, line in enumerate(page.iter('LINE')):

--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -359,13 +359,11 @@ class TocPageDetectorModule(KeywordPageDetectorModule):
         super().__init__(["table of content"], match_limit=1)
 
     def detectTocHeading(self, page):
-        for line in page.iter('LINE'):
-            heading = ""
-            for word in line.iter('WORD'):
-                heading = heading + " " + word.text
-            if heading.lower().strip() in self.keywords:
+        for i, line in enumerate(page.iter('LINE')):
+            if i < 5:  # if we're in the first few lines
+            words = " ".join(line.iter('WORD')).lower().strip()
+            if any(kws == words for kws in self.keywords):
                 return True
-        
         return False
 
 

--- a/mysequencer.py
+++ b/mysequencer.py
@@ -1,0 +1,17 @@
+from bgp import ia
+from bgp import Sequencer
+from bgp.modules.terms import TocPageDetectorModule, PageTypeProcessor, CopyrightPageDetectorModule
+
+
+PageTypeDetectionSequencer = Sequencer({
+    "pagetypes": PageTypeProcessor(modules={
+        "toc_page": TocPageDetectorModule()
+    })
+})
+
+
+book = ia.get_item("9780262517638OpenAccess") 
+
+results = PageTypeDetectionSequencer.sequence(book).results
+
+print(results)


### PR DESCRIPTION
@mekarpeles , In [bgp/modules/terms.py](https://github.com/Hitansh-Shah/sequencer/blob/2b4aeca38312f735d781f31bff5a652402108dcc/bgp/modules/terms.py#:~:text=class%20TocPageDetectorModule(KeywordPageDetectorModule,contents%27%5D%2C%20match_limit%3D1)), I have added the `class` for `TocPageDetectorModule`. It is a simple class copied from `CopyrightPageDetectorModule`. I removed the `extractor` function and changed the `keywords` for table of contents. I have also added [mysequencer.py](https://github.com/Hitansh-Shah/sequencer/blob/2b4aeca38312f735d781f31bff5a652402108dcc/mysequencer.py), a temporary file in the root of the project for defining a sequencer which only detects Table of contents page. 