### PR TITLE
tighten rules around isbn char substititions

### DIFF
--- a/bgp/modules/terms.py
+++ b/bgp/modules/terms.py
@@ -186,7 +186,7 @@ def rmpunk(word, punctuation=PUNCTUATION):
     )
 
 def replace_mistakes(word):
-    substitutions = [('I', '1'), ('O', '0'), ('l', '1'), ('D', '0'), ('A', '8'), ('/', 'X'), ('\\', 'X'), ('S', '5')]
+    substitutions = [('I', '1'), ('O', '0'), ('l', '1'), ('S', '5')]
     for sub in substitutions:
         word = word.replace(*sub)
     return word


### PR DESCRIPTION
Some books have things which are close to ISBN (like a bank account) which are getting parsed into valid ISBNs (what are the chances!)

e.g. https://archive.org/details/isbn_1842738577 